### PR TITLE
Use pip3, pre-commit v2.13.0 and split RUN

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: master
+    rev: v4.0.1
     hooks:
       - { id: check-case-conflict }
       - { id: check-merge-conflict }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: master  # Use the ref you want to point at
     hooks:
       - { id: check-case-conflict }
       - { id: check-merge-conflict }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: master
     hooks:
       - { id: check-case-conflict }
       - { id: check-merge-conflict }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 FROM debian:stable-slim
 
-ENV PRE_COMMIT_VERSION 1.5.1
+ENV PRE_COMMIT_VERSION 2.13.0
+
+WORKDIR /pre-commit
+
 RUN apt-get update && apt-get install -y \
       build-essential \
       git \
-      python-pip \
-      python3 && \
-      pip install pre-commit==${PRE_COMMIT_VERSION} \
-      && mkdir /pre-commit && \
-      cd /pre-commit && \
-      git init . && \
-      pre-commit install
+      python3-pip \
+      python3 \
+      && rm -rf /var/lib/apt/lists/*
+      
+RUN git init .
 
-WORKDIR /pre-commit
+RUN pip3 install pre-commit==${PRE_COMMIT_VERSION} && \      
+      pre-commit install
 
 CMD ["pre-commit", "run", "--all-files"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ RUN apt-get update && apt-get install -y \
       python3-pip \
       python3 \
       && rm -rf /var/lib/apt/lists/*
-      
+
 RUN git init .
 
-RUN pip3 install pre-commit==${PRE_COMMIT_VERSION} && \      
+RUN pip3 install pre-commit==${PRE_COMMIT_VERSION} && \
       pre-commit install
 
 CMD ["pre-commit", "run", "--all-files"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM debian:stable-slim
 
+ENV PRE_COMMIT_VERSION 1.5.1
 RUN apt-get update && apt-get install -y \
       build-essential \
       git \
       python-pip \
       python3 && \
-      pip install pre-commit \
+      pip install pre-commit==${PRE_COMMIT_VERSION} \
       && mkdir /pre-commit && \
       cd /pre-commit && \
       git init . && \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [Pre-commit](http://pre-commit.com/) is a tool created by Yelp that allows you to run pre-commit sanity checks against your repo, to do things like ensuring private keys aren't being added etc. This image packages `pre-commit` in a docker-container, so you can ship it with a setup script you might be using to setup local development environment.
 
 # Usage
-- Create `.pre-commit-config.yaml` in the root of your repo. For example   
+- Create `.pre-commit-config.yaml` in the root of your repo. For example
 
   ```yaml
   - repo: git://github.com/pre-commit/pre-commit-hooks
@@ -17,31 +17,41 @@
       - { id: end-of-file-fixer }
       - { id: trailing-whitespace }
   ```
-- Add `pre-commit` script to `.git/hooks/pre-commit`  
+- Add `pre-commit` script to `.git/hooks/pre-commit`
   ```shell
-  cd $(git rev-parse --show-toplevel)
+  #!/bin/sh
+  toplevel="`git rev-parse --show-toplevel`"
+  cd "$toplevel"
 
-  NAME=$(basename `git rev-parse --show-toplevel`)_precommit
-  docker ps -a | grep $NAME &> /dev/null
+  NAME="`basename "$toplevel"`_precommit"
+
+  if command -v podman > /dev/null 2>&1; then
+      container_exec=podman
+  elif command -v docker > /dev/null 2>&1; then
+      container_exec=docker
+  else
+      echo "No container executable found! Looked for \`podman' and \`docker'."
+      exit 1
+  fi
+  test -n "`"$container_exec" ps -a -q --no-trunc --filter 'name=^/?'"$NAME"'$'`"
   CONTAINER_EXISTS=$?
 
-  if [[ CONTAINER_EXISTS -eq 0 ]]; then
-      docker restart $NAME && docker attach --no-stdin $NAME
+  if [ "$CONTAINER_EXISTS" -eq 0 ]; then
+      "$container_exec" restart "$NAME" && "$container_exec" attach --no-stdin "$NAME"
   else
-      docker run -t -v $(pwd):/pre-commit --name $NAME taghash/pre-commit
+      "$container_exec" run -t -v $(pwd):/pre-commit --name "$NAME" alexs77/pre-commit
   fi
-
   ```
-- Create an empty commit to test  
-  ```git commit --allow-empty -m "Test pre-commit"```
+- Create an empty commit to test
+  ```shell
+  git commit --allow-empty -m "Test pre-commit"
+  ```
 
 # Note
 - If you are going to use a `pre-commit` plugin that needs dependencies not packaged in this image, you can extend this image and install the dependencies you need
-- You might need to change the command, add volumes etc, based on your needs.  
-  For example, if you add `{ id: detect-aws-credentials }` to `.pre-commit-config.yaml`, you have to mount the directory holding your aws credentials.  
-  The docker command (as in the `pre-commit` script) would then become  
+- You might need to change the command, add volumes etc, based on your needs.
+  For example, if you add `{ id: detect-aws-credentials }` to `.pre-commit-config.yaml`, you have to mount the directory holding your aws credentials.
+  The docker command (as in the `pre-commit` script) would then become
   ```shell
-  docker run -t -v $(pwd):/pre-commit -v $HOME/.aws:/root/.aws:ro --name $NAME taghash/pre-commit
+  "$container_exec" run -t -v $(pwd):/pre-commit -v $HOME/.aws:/root/.aws:ro --name $NAME alexs77/pre-commit
   ```
-
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Pre-commit Docker image
-[Pre-commit](http://pre-commit.com/) is a tool created by Yelp that allows you to run pre-commit sanity checks against your repo, to do things like ensuring private keys aren't being added etc. This image packages `pre-commit` in a docker-container, so you can ship it with a setup script you might be using to setup local development environment.
+
+[Pre-commit](http://pre-commit.com/) is a tool created by Yelp that
+allows you to run pre-commit sanity checks against your repo, to do
+things like ensuring private keys aren't being added etc. This image
+packages `pre-commit` in a docker-container, so you can ship it with
+a setup script you might be using to setup local development environment.
 
 # Usage
+
 - Create `.pre-commit-config.yaml` in the root of your repo. For example
 
   ```yaml
@@ -21,10 +27,11 @@
   ```shell
   #!/bin/sh
   toplevel="`git rev-parse --show-toplevel`"
-  cd "$toplevel"
-
   NAME="`basename "$toplevel"`_precommit"
 
+  cd "$toplevel"
+
+  # Find container executable; either podman or docker
   if command -v podman > /dev/null 2>&1; then
       container_exec=podman
   elif command -v docker > /dev/null 2>&1; then
@@ -33,11 +40,13 @@
       echo "No container executable found! Looked for \`podman' and \`docker'."
       exit 1
   fi
+
+  # Is there already a container for this source directory?
   test -n "`"$container_exec" ps -a -q --no-trunc --filter 'name=^/?'"$NAME"'$'`"
   CONTAINER_EXISTS=$?
 
   if [ "$CONTAINER_EXISTS" -eq 0 ]; then
-      "$container_exec" restart "$NAME" && "$container_exec" attach --no-stdin "$NAME"
+      "$container_exec" restart "$NAME" >/dev/null && "$container_exec" attach --no-stdin "$NAME"
   else
       "$container_exec" run -t -v $(pwd):/pre-commit --name "$NAME" alexs77/pre-commit
   fi
@@ -48,9 +57,13 @@
   ```
 
 # Note
-- If you are going to use a `pre-commit` plugin that needs dependencies not packaged in this image, you can extend this image and install the dependencies you need
-- You might need to change the command, add volumes etc, based on your needs.
-  For example, if you add `{ id: detect-aws-credentials }` to `.pre-commit-config.yaml`, you have to mount the directory holding your aws credentials.
+- If you are going to use a `pre-commit` plugin that needs dependencies
+  not packaged in this image, you can extend this image and install the
+  dependencies you need
+- You might need to change the command, add volumes etc, based on your
+  needs.
+  For example, if you add `{ id: detect-aws-credentials }` to `.pre-commit-config.yaml`,
+  you have to mount the directory holding your aws credentials.
   The docker command (as in the `pre-commit` script) would then become
   ```shell
   "$container_exec" run -t -v $(pwd):/pre-commit -v $HOME/.aws:/root/.aws:ro --name $NAME alexs77/pre-commit

--- a/pre-commit
+++ b/pre-commit
@@ -1,11 +1,22 @@
-cd $(git rev-parse --show-toplevel)
+#!/bin/sh
+toplevel="`git rev-parse --show-toplevel`"
+cd "$toplevel"
 
-NAME=$(basename `git rev-parse --show-toplevel`)_precommit
-docker ps -a | grep nucleus_precommit &> /dev/null
+NAME="`basename "$toplevel"`_precommit"
+
+if command -v podman > /dev/null 2>&1; then
+    container_exec=podman
+elif command -v docker > /dev/null 2>&1; then
+    container_exec=docker
+else
+    echo "No container executable found! Looked for \`podman' and \`docker'."
+    exit 1
+fi
+test -n "`"$container_exec" ps -a -q --no-trunc --filter 'name=^/?'"$NAME"'$'`"
 CONTAINER_EXISTS=$?
 
-if [[ CONTAINER_EXISTS -eq 0 ]]; then
-    docker restart $NAME && docker attach --no-stdin $NAME
+if [ "$CONTAINER_EXISTS" -eq 0 ]; then
+    "$container_exec" restart "$NAME" && "$container_exec" attach --no-stdin "$NAME"
 else
-    docker run -t -v $(pwd):/pre-commit --name $NAME taghash/pre-commit
+    "$container_exec" run -t -v $(pwd):/pre-commit --name "$NAME" alexs77/pre-commit
 fi

--- a/pre-commit
+++ b/pre-commit
@@ -1,9 +1,10 @@
 #!/bin/sh
 toplevel="`git rev-parse --show-toplevel`"
-cd "$toplevel"
-
 NAME="`basename "$toplevel"`_precommit"
 
+cd "$toplevel"
+
+# Find container executable; either podman or docker
 if command -v podman > /dev/null 2>&1; then
     container_exec=podman
 elif command -v docker > /dev/null 2>&1; then
@@ -12,11 +13,13 @@ else
     echo "No container executable found! Looked for \`podman' and \`docker'."
     exit 1
 fi
+
+# Is there already a container for this source directory?
 test -n "`"$container_exec" ps -a -q --no-trunc --filter 'name=^/?'"$NAME"'$'`"
 CONTAINER_EXISTS=$?
 
 if [ "$CONTAINER_EXISTS" -eq 0 ]; then
-    "$container_exec" restart "$NAME" && "$container_exec" attach --no-stdin "$NAME"
+    "$container_exec" restart "$NAME" >/dev/null && "$container_exec" attach --no-stdin "$NAME"
 else
     "$container_exec" run -t -v $(pwd):/pre-commit --name "$NAME" alexs77/pre-commit
 fi


### PR DESCRIPTION
pre-commit is now at v2.13.0 and requires Python 3. Install the `python3-pip` package for that and use `pip3`.
Also split the one `RUN` command into separate ones, so that an update of pre-commit doesn't require a rebuild of everything.